### PR TITLE
chore(boot): Tweak service provider boot

### DIFF
--- a/src/DataExportServiceProvider.php
+++ b/src/DataExportServiceProvider.php
@@ -2,18 +2,20 @@
 
 namespace Worksome\DataExport;
 
-use Illuminate\Support\ServiceProvider;
-use Worksome\DataExport\Delivery\Contracts\Delivery;
-use Worksome\DataExport\Delivery\DeliveryManager;
-use Worksome\DataExport\Generator\Contracts\Generator;
-use Worksome\DataExport\Generator\GeneratorManager;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\ServiceProvider;
+use Nuwave\Lighthouse\Events\BuildSchemaString;
+use Nuwave\Lighthouse\Schema\Source\SchemaStitcher;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
 use Nuwave\Lighthouse\Schema\Types\LaravelEnumType;
+use Worksome\DataExport\Delivery\Contracts\Delivery;
+use Worksome\DataExport\Delivery\DeliveryManager;
 use Worksome\DataExport\Enums\DeliveryType;
 use Worksome\DataExport\Enums\ExportResonseStatus;
 use Worksome\DataExport\Enums\ExportType;
 use Worksome\DataExport\Enums\GeneratorType;
+use Worksome\DataExport\Generator\Contracts\Generator;
+use Worksome\DataExport\Generator\GeneratorManager;
 
 class DataExportServiceProvider extends ServiceProvider
 {
@@ -25,16 +27,29 @@ class DataExportServiceProvider extends ServiceProvider
 
     public function boot(Dispatcher $dispatcher, TypeRegistry $typeRegistry): void
     {
-        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        $this->registerMigrations();
+        $this->buildQraphQLSchema($dispatcher);
+        $this->registerGraphQLTypes($typeRegistry);
+    }
 
-        $dispatcher->listen(
-            \Nuwave\Lighthouse\Events\BuildSchemaString::class,
-            function(): string {
-                $stitcher = new \Nuwave\Lighthouse\Schema\Source\SchemaStitcher(__DIR__ . '/../GraphQL/schema.graphql');
-                return $stitcher->getSchemaString();
-            }
-        );
+    private function registerMigrations(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+        }
+    }
 
+    private function buildQraphQLSchema(Dispatcher $dispatcher): void
+    {
+        $dispatcher->listen(BuildSchemaString::class, function(): string {
+            $stitcher = new SchemaStitcher(__DIR__ . '/../GraphQL/schema.graphql');
+
+            return $stitcher->getSchemaString();
+        });
+    }
+
+    private function registerGraphQLTypes(TypeRegistry $typeRegistry): void
+    {
         $types = collect([
             ExportType::class,
             ExportResonseStatus::class,


### PR DESCRIPTION
This tweaks the service provider boot method:

- It only loads the migrations if running on console.
- Moved the other things into dedicated methods.