### PR TITLE
chore: Expose Generator File on Completed event

### DIFF
--- a/src/Events/ExportCompleted.php
+++ b/src/Events/ExportCompleted.php
@@ -5,6 +5,7 @@ namespace Worksome\DataExport\Events;
 use Illuminate\Broadcasting\InteractsWithSockets;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
+use Worksome\DataExport\Generator\GeneratorFile;
 use Worksome\DataExport\Models\Export;
 
 class ExportCompleted
@@ -14,6 +15,7 @@ class ExportCompleted
     use SerializesModels;
 
     public function __construct(
-        public Export $export
+        public Export $export,
+        public GeneratorFile $generatorFile,
     ) {}
 }

--- a/src/Services/UpdateExport.php
+++ b/src/Services/UpdateExport.php
@@ -29,7 +29,7 @@ class UpdateExport
 
         $export->save();
 
-        event(new ExportCompleted($export));
+        event(new ExportCompleted($export, $generatorFile));
 
         return $export;
     }


### PR DESCRIPTION
This exposes the generator file object on the completed event, so we can easily and more reliably determine if the export file is empty or not.