### PR TITLE
feat(compliances): JIRA-3322 Add support for comp.

### DIFF
--- a/tests/Fake/FakeProcessorWithComplianceDriver.php
+++ b/tests/Fake/FakeProcessorWithComplianceDriver.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Worksome\DataExport\Tests\Fake;
+
+use Worksome\DataExport\Models\Export;
+use Worksome\DataExport\Processor\EloquentProcessor;
+use Worksome\DataExport\Processor\ProcessorData;
+use Worksome\DataExport\Tests\Fake\Models\User;
+
+class FakeProcessorWithComplianceDriver extends EloquentProcessor
+{
+    public string $type = 'fake';
+
+    public array $columns = [
+        'id' => 'User ID',
+        'name',
+        'is_admin' => 'Is Admin',
+    ];
+
+    public function process(Export $export): ProcessorData
+    {
+        $query = User::query();
+
+        $data = $this->filterQuery($query);
+
+        return new ProcessorData($data, $this->type);
+    }
+
+    public function compliances($item): array
+    {
+        return [
+            ['Compliance UK' => 'applies'],
+            ['Compliance US' => 'none']
+        ];
+    }
+}

--- a/tests/Feature/Processor/EloquentProcessorTest.php
+++ b/tests/Feature/Processor/EloquentProcessorTest.php
@@ -5,6 +5,7 @@ namespace Worksome\DataExport\Tests\Feature\Processor;
 use Worksome\DataExport\Models\Export;
 use Worksome\DataExport\Tests\Factories\UserFactory;
 use Worksome\DataExport\Tests\Fake\FakeProcessorDriver;
+use Worksome\DataExport\Tests\Fake\FakeProcessorWithComplianceDriver;
 
 it('can process a query that returns no results', function () {
     $export = new Export();
@@ -49,5 +50,42 @@ it('can process a query that returns results with filtered columns', function ()
         'User ID'  => '2',
         'name'     => 'User Two',
         'Is Admin' => '0',
+    ]);
+});
+
+it('should correctly process compliance data', function () {
+    UserFactory::new()->create([
+        'name'     => 'User One',
+        'is_admin' => true,
+    ]);
+    UserFactory::new()->create([
+        'name'     => 'User Two',
+        'is_admin' => false,
+    ]);
+
+    $export = new Export();
+    $processor = new FakeProcessorWithComplianceDriver();
+    $processedData = $processor->process($export);
+    $data = $processedData->getData();
+
+    foreach ($data as $item) {
+        $this->assertArrayHasKey('Compliance UK', $item);
+        $this->assertArrayHasKey('Compliance US', $item);
+    }
+
+    expect($data[0])->toBe([
+        "User ID" => "1",
+        "name" => "User One",
+        "Is Admin" => "1",
+        "Compliance UK" => "applies",
+        "Compliance US" => "none"
+    ]);
+
+    expect($data[1])->toBe([
+        "User ID" => "2",
+        "name" => "User Two",
+        "Is Admin" => "0",
+        "Compliance UK" => "applies",
+        "Compliance US" => "none"
     ]);
 });


### PR DESCRIPTION
Add support for compliance data in the data exports with column normalization.

Basically to simply put this:

- I create a temporary key for `compliances` for each item, where I gather all compliance data
- Then I loop through all the items and get unique keys for compliances, that will give me which and how many columns I'll need. E.g. `IR35` column and then `Empoyment Classification` column
- Then I go through all the items and add these additional columns for each item and populate it with data if exists. If not I just leave it blank
- This will result in normalized data
- The reason of the public `compliances` function is so that we can use `ComplianceApplier` on the platform : https://github.com/worksome/platform/pull/4646/files#diff-3def838a44bf8b9e3d07d4cd4d2410b91e7901562bdc4684823193a75a735ddcR82-R92