### PR TITLE
refactor: rename `Args` to `ArgsInput`

### DIFF
--- a/GraphQL/Inputs/CreateExportInput.graphql
+++ b/GraphQL/Inputs/CreateExportInput.graphql
@@ -1,4 +1,4 @@
-input Args {
+input ArgsInput {
     companies: [Int!]!,
     dateFrom: Date
     dateTo: Date
@@ -12,5 +12,5 @@ input CreateExportInput {
     type: String!
     generatorType: String!
     deliveries: [String!]!
-    args: Args!
+    args: ArgsInput!
 }


### PR DESCRIPTION
This change is in-line with our new GraphQL standards.