### PR TITLE
chore: add missing description to GraphQL

### DIFF
--- a/GraphQL/Mutations/CreateExport.graphql
+++ b/GraphQL/Mutations/CreateExport.graphql
@@ -17,5 +17,10 @@ extend type Mutation {
     Create export for given input
     The export url and count of rows will be returned (minus headings)
     """
-    createExport(input: CreateExportInput!): CreateExportResponse @field(resolver: "\\Worksome\\DataExport\\GraphQL\\Mutations\\CreateExport")
+    createExport(
+        """
+        The input for creating an export.
+        """
+        input: CreateExportInput!
+    ): CreateExportResponse @field(resolver: "\\Worksome\\DataExport\\GraphQL\\Mutations\\CreateExport")
 }


### PR DESCRIPTION
Looks like this was the last missed description. 👍🏻 This should allow CI to pass.