### PR TITLE
fix(exports): JIRA-8568 Fix timezones

### DIFF
--- a/src/Services/CreateExport.php
+++ b/src/Services/CreateExport.php
@@ -2,6 +2,7 @@
 
 namespace Worksome\DataExport\Services;
 
+use Carbon\Carbon;
 use Worksome\DataExport\Enums\ExportStatus;
 use Worksome\DataExport\Models\Export;
 
@@ -18,6 +19,10 @@ class CreateExport
 
     public function run(): Export
     {
+        $dtoArgs = $this->dto->getArgs();
+        $dateTo = Carbon::parse($dtoArgs['dateTo'])->toDateString();
+        $dateFrom = Carbon::parse($dtoArgs['dateFrom'])->toDateString();
+
         return Export::create([
             'user_id' => $this->dto->getUserId(),
             'impersonator_id' => $this->dto->getImpersonatorId(),
@@ -27,7 +32,13 @@ class CreateExport
             'type' => $this->dto->getType(),
             'generator_type' => $this->dto->getGeneratorType(),
             'deliveries' => $this->dto->getDeliveries(),
-            'args' => $this->dto->getArgs(),
+            'args' => array_merge(
+                $dtoArgs,
+                [
+                    'dateTo' => $dateTo,
+                    'dateFrom' => $dateFrom,
+                ]
+            )
         ]);
     }
 }

--- a/tests/Feature/GraphQL/Mutations/CreateExportTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateExportTest.php
@@ -7,6 +7,7 @@ use Worksome\DataExport\Enums\ExportResponseStatus;
 use Worksome\DataExport\Events\ExportInitialised;
 use Worksome\DataExport\GraphQL\Mutations\CreateExport;
 use Worksome\DataExport\GraphQL\NullExportValidator;
+use Worksome\DataExport\Models\Export;
 use Worksome\DataExport\Services\CreateExport as CreateExportService;
 
 it('can create an export', function () {
@@ -37,4 +38,36 @@ it('can create an export', function () {
     Event::assertDispatched(ExportInitialised::class);
 
     expect($response['status'])->toBe(ExportResponseStatus::SUCCESS);
+
+    $export = Export::latest('created_at')->first()->refresh();
+    expect($export->args['dateFrom'])->toBe('2021-01-01');
+    expect($export->args['dateTo'])->toBe('2021-01-02');
+});
+
+it('can exports with correct dates', function () {
+    $args = [
+        'input' => [
+            'userId'      => 1,
+            'accountId'   => 1,
+            'accountType' => 'user',
+            'type'        => 'contract',
+            'generatorType' => 'csv',
+            'deliveries'    => [
+                ['type' => 'email', 'value' => 'john@doe.com'],
+            ],
+            'args' => [
+                'dateFrom' => '2022-01-01T23:00:00.000000Z',
+                'dateTo' => '2022-01-01T23:00:00.000000Z',
+            ],
+        ],
+    ];
+
+    $service = new CreateExportService();
+    $validator = new NullExportValidator();
+
+    (new CreateExport($service, $validator))->__invoke(null, $args);
+
+    $export = Export::latest('created_at')->first()->refresh();
+    expect($export->args['dateFrom'])->toBe('2022-01-01');
+    expect($export->args['dateTo'])->toBe('2022-01-01');
 });


### PR DESCRIPTION
Whenever an export is created, the timezone being saved was wrong and resulted in moving the dates +-1 day.

Context: https://stackoverflow.com/questions/60649769/wrong-timezone-in-laravel-7-after-date-serialization

Shout out to @brunogaspar for coming up with the fix ❤️ 