### PR TITLE
feat: refactor to native enums

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,6 @@
     "license": "MIT",
     "require": {
         "php": "^8.3",
-        "bensampo/laravel-enum": "^6.11",
         "guzzlehttp/guzzle": "^7.8",
         "illuminate/container": "^11.0 || ^12.0",
         "illuminate/contracts": "^11.0 || ^12.0",
@@ -14,7 +13,8 @@
         "nesbot/carbon": "^2.72 || ^3.0",
         "nuwave/lighthouse": "^6.54",
         "phpoffice/phpspreadsheet": "^1.29.10 || ^2.3.8",
-        "symfony/dependency-injection": "^6.4 || ^7.0"
+        "symfony/dependency-injection": "^6.4 || ^7.0",
+        "worksome/graphql-helpers": "^0.1.15"
     },
     "require-dev": {
         "larastan/larastan": "^3.1",

--- a/src/DataExportServiceProvider.php
+++ b/src/DataExportServiceProvider.php
@@ -7,13 +7,13 @@ use Illuminate\Support\ServiceProvider;
 use Nuwave\Lighthouse\Events\BuildSchemaString;
 use Nuwave\Lighthouse\Schema\Source\SchemaStitcher;
 use Nuwave\Lighthouse\Schema\TypeRegistry;
-use Nuwave\Lighthouse\Schema\Types\LaravelEnumType;
 use Worksome\DataExport\Enums\ExportResponseStatus;
 use Worksome\DataExport\Enums\GeneratorType;
 use Worksome\DataExport\Generator\GeneratorManager;
 use Worksome\DataExport\GraphQL\Contracts\ExportValidator;
 use Worksome\DataExport\GraphQL\NullExportValidator;
 use Worksome\DataExport\Processor\ProcessorRepository;
+use Worksome\GraphQLHelpers\Definition\PhpEnumType;
 
 class DataExportServiceProvider extends ServiceProvider
 {
@@ -28,7 +28,7 @@ class DataExportServiceProvider extends ServiceProvider
     {
         $this->registerMigrations();
         $this->callAfterResolving(Dispatcher::class, function (Dispatcher $dispatcher) {
-            $this->buildQraphQLSchema($dispatcher);
+            $this->buildGraphQLSchema($dispatcher);
         });
         $this->callAfterResolving(TypeRegistry::class, function (TypeRegistry $typeRegistry) {
             $this->registerGraphQLTypes($typeRegistry);
@@ -42,7 +42,7 @@ class DataExportServiceProvider extends ServiceProvider
         }
     }
 
-    private function buildQraphQLSchema(Dispatcher $dispatcher): void
+    private function buildGraphQLSchema(Dispatcher $dispatcher): void
     {
         $dispatcher->listen(BuildSchemaString::class, function (): string {
             $stitcher = new SchemaStitcher(__DIR__ . '/../GraphQL/schema.graphql');
@@ -59,7 +59,7 @@ class DataExportServiceProvider extends ServiceProvider
         ];
 
         foreach ($types as $type) {
-            $typeRegistry->register(new LaravelEnumType($type));
+            $typeRegistry->register(new PhpEnumType($type));
         }
     }
 }

--- a/src/Enums/ExportResponseStatus.php
+++ b/src/Enums/ExportResponseStatus.php
@@ -2,15 +2,17 @@
 
 namespace Worksome\DataExport\Enums;
 
-use BenSampo\Enum\Enum;
+use GraphQL\Type\Definition\Description;
+use Worksome\GraphQLHelpers\Definition\Concerns\GraphQLConvertable;
 
-/**
- * @method static static SUCCESS()
- * @method static static ERROR()
- */
-final class ExportResponseStatus extends Enum
+#[Description('The status of the export.')]
+enum ExportResponseStatus: string
 {
-    public const SUCCESS = 'success';
+    use GraphQLConvertable;
 
-    public const ERROR = 'error';
+    #[Description('The export was successful.')]
+    case Success = 'success';
+
+    #[Description('The export experienced one or more errors.')]
+    case Error = 'error';
 }

--- a/src/Enums/ExportStatus.php
+++ b/src/Enums/ExportStatus.php
@@ -2,11 +2,8 @@
 
 namespace Worksome\DataExport\Enums;
 
-use BenSampo\Enum\Enum;
-
-final class ExportStatus extends Enum
+enum ExportStatus: string
 {
-    public const AWAITING = 'awaiting';
-
-    public const COMPLETED = 'completed';
+    case Awaiting = 'awaiting';
+    case Completed = 'completed';
 }

--- a/src/Enums/GeneratorType.php
+++ b/src/Enums/GeneratorType.php
@@ -2,12 +2,11 @@
 
 namespace Worksome\DataExport\Enums;
 
-use BenSampo\Enum\Enum;
+use GraphQL\Type\Definition\Description;
 
-/**
- * @method static static CSV()
- */
-final class GeneratorType extends Enum
+#[Description('The types of export that can be generated.')]
+enum GeneratorType: string
 {
-    public const CSV = 'CSV';
+    #[Description('Comma-separated values (CSV).')]
+    case CSV = 'CSV';
 }

--- a/src/GraphQL/Mutations/CreateExport.php
+++ b/src/GraphQL/Mutations/CreateExport.php
@@ -31,7 +31,7 @@ class CreateExport
         event(new ExportInitialised($export));
 
         return [
-            'status' => ExportResponseStatus::SUCCESS,
+            'status' => ExportResponseStatus::Success,
             'message' => __('Export initialised. You\'ll receive an email when the export is completed.'),
         ];
     }

--- a/src/Models/Export.php
+++ b/src/Models/Export.php
@@ -3,22 +3,23 @@
 namespace Worksome\DataExport\Models;
 
 use Illuminate\Database\Eloquent\Model;
+use Worksome\DataExport\Enums\ExportStatus;
 
 /**
- * @property int    $id
- * @property int    $user_id
- * @property int    $impersonator_id
- * @property int    $account_id
- * @property string $account_type
- * @property string $path
- * @property string $status
- * @property string $type
- * @property string $generator_type
- * @property array  $deliveries
- * @property array  $args
- * @property float  $size
- * @property int    $total_rows
- * @property string $mime_type
+ * @property int          $id
+ * @property int          $user_id
+ * @property int          $impersonator_id
+ * @property int          $account_id
+ * @property string       $account_type
+ * @property string       $path
+ * @property ExportStatus $status
+ * @property string       $type
+ * @property string       $generator_type
+ * @property array        $deliveries
+ * @property array        $args
+ * @property float        $size
+ * @property int          $total_rows
+ * @property string       $mime_type
  */
 class Export extends Model
 {
@@ -38,12 +39,17 @@ class Export extends Model
         'mime_type',
     ];
 
-    protected $casts = [
-        'args'       => 'array',
-        'deliveries' => 'array',
-        'size'       => 'float',
-        'total_rows' => 'integer',
-    ];
+    /** {@inheritdoc} */
+    protected function casts(): array
+    {
+        return [
+            'args'       => 'array',
+            'deliveries' => 'array',
+            'size'       => 'float',
+            'total_rows' => 'integer',
+            'status'     => ExportStatus::class,
+        ];
+    }
 
     public function getFormattedSize(): string
     {

--- a/src/Services/CreateExport.php
+++ b/src/Services/CreateExport.php
@@ -28,7 +28,7 @@ class CreateExport
             'impersonator_id' => $this->dto->getImpersonatorId(),
             'account_id' => $this->dto->getAccountId(),
             'account_type' => $this->dto->getAccountType(),
-            'status' => ExportStatus::AWAITING,
+            'status' => ExportStatus::Awaiting,
             'type' => $this->dto->getType(),
             'generator_type' => $this->dto->getGeneratorType(),
             'deliveries' => $this->dto->getDeliveries(),

--- a/src/Services/UpdateExport.php
+++ b/src/Services/UpdateExport.php
@@ -22,7 +22,7 @@ class UpdateExport
         $generatorFile = $this->dto->getGeneratorFile();
 
         $export = $this->dto->getExport();
-        $export->status = ExportStatus::COMPLETED;
+        $export->status = ExportStatus::Completed;
         $export->path = $generatorFile->getPath();
         $export->size = $generatorFile->getSize();
         $export->total_rows = $generatorFile->getCount();

--- a/tests/Factories/ExportFactory.php
+++ b/tests/Factories/ExportFactory.php
@@ -13,7 +13,7 @@ class ExportFactory extends Factory
     public function definition(): array
     {
         return [
-            'status'       => ExportStatus::AWAITING,
+            'status'       => ExportStatus::Awaiting,
             'user_id'      => 1,
             'account_id'   => 1,
             'account_type' => 'user',

--- a/tests/Feature/GraphQL/Mutations/CreateExportTest.php
+++ b/tests/Feature/GraphQL/Mutations/CreateExportTest.php
@@ -37,11 +37,13 @@ it('can create an export', function () {
 
     Event::assertDispatched(ExportInitialised::class);
 
-    expect($response['status'])->toBe(ExportResponseStatus::SUCCESS);
+    expect($response['status'])->toBe(ExportResponseStatus::Success);
 
     $export = Export::latest('created_at')->first()->refresh();
-    expect($export->args['dateFrom'])->toBe('2021-01-01');
-    expect($export->args['dateTo'])->toBe('2021-01-02');
+
+    expect($export->args)
+        ->dateFrom->toBe('2021-01-01')
+        ->dateTo->toBe('2021-01-02');
 });
 
 it('can exports with correct dates', function () {
@@ -68,6 +70,7 @@ it('can exports with correct dates', function () {
     (new CreateExport($service, $validator))->__invoke(null, $args);
 
     $export = Export::latest('created_at')->first()->refresh();
-    expect($export->args['dateFrom'])->toBe('2022-01-01');
-    expect($export->args['dateTo'])->toBe('2022-01-01');
+    expect($export->args)
+        ->dateFrom->toBe('2022-01-01')
+        ->dateTo->toBe('2022-01-01');
 });

--- a/tests/Feature/Services/CreateExportTest.php
+++ b/tests/Feature/Services/CreateExportTest.php
@@ -29,7 +29,7 @@ it('can create an export', function () {
 
     $result = $service->run();
 
-    expect($result->status)->toBe(ExportStatus::AWAITING);
+    expect($result->status)->toBe(ExportStatus::Awaiting);
     expect($result->user_id)->toBe($args['userId']);
     expect($result->account_id)->toBe($args['accountId']);
     expect($result->account_type)->toBe($args['accountType']);

--- a/tests/Feature/Services/UpdateExportTest.php
+++ b/tests/Feature/Services/UpdateExportTest.php
@@ -26,7 +26,7 @@ it('can update an export', function () {
 
     $result = $service->run();
 
-    expect($result->status)->toBe(ExportStatus::COMPLETED);
+    expect($result->status)->toBe(ExportStatus::Completed);
     expect($result->path)->not->toBeNull();
     expect($result->size)->not->toBeNull();
     expect($result->mime_type)->not->toBeNull();


### PR DESCRIPTION
~This requires #105 to be merged.~

> [!Warning]
> This is a breaking change, and requires a major version bump.
>
> **BREAKING CHANGES**
> - `ExportResponseStatus`, `ExportStatus`, and `GeneratorType` have been changed to native enums
> - `Export.status` has changed from type `string` to `ExportStatus`
> - Enums have changed in the GraphQL API to macro-case